### PR TITLE
Check for `Terminal42NodeBundle`

### DIFF
--- a/src/Resources/contao/dca/tl_node.php
+++ b/src/Resources/contao/dca/tl_node.php
@@ -11,7 +11,8 @@
 
 use Contao\System;
 use Symfony\Component\HttpFoundation\Request;
+use Terminal42\NodeBundle\Terminal42NodeBundle;
 
-if (System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(System::getContainer()->get('request_stack')->getCurrentRequest() ?? Request::create(''))) {
+if (class_exists(Terminal42NodeBundle::class)) {
     $GLOBALS['TL_DCA']['tl_node']['list']['label']['label_callback'] = array('memo.backendoptim.listener.data_container', 'onCustomLabelCallback');
 }

--- a/src/Resources/contao/dca/tl_node.php
+++ b/src/Resources/contao/dca/tl_node.php
@@ -9,8 +9,6 @@
  * @author    Rory Zünd, Media Motion AG
  */
 
-use Contao\System;
-use Symfony\Component\HttpFoundation\Request;
 use Terminal42\NodeBundle\Terminal42NodeBundle;
 
 if (class_exists(Terminal42NodeBundle::class)) {


### PR DESCRIPTION
This PR adds a check whether the `Terminal42NodeBundle` actually exists. Otherwise an empty DCA will be generated.

This PR also removes the back end request check, as that is not really necessary.